### PR TITLE
Revert "Renamed StartPath EXE."

### DIFF
--- a/LastOasis.cs/LastOasis.cs
+++ b/LastOasis.cs/LastOasis.cs
@@ -34,7 +34,7 @@ namespace WindowsGSM.Plugins
 
 
         // - Game server Fixed variables
-        public override string StartPath => @"Mist\Binaries\Win64\MistServer.exe"; // Game server start path
+        public override string StartPath => @"Mist\Binaries\Win64\MistServer-Win64-Shipping.exe"; // Game server start path
         public string FullName = "LastOasis Dedicated Server"; // Game server FullName
         public bool AllowsEmbedConsole = true;  // Does this server support output redirect?
         public int PortIncrements = 2; // This tells WindowsGSM how many ports should skip after installation


### PR DESCRIPTION
This reverts commit aef056cb58fcff23a0e298b00b84d9198cb452d6.

[Donkey Crew](https://store.steampowered.com/search/?developer=Donkey%20Crew&snr=1_5_9__2000) renamed back on their end, and so must we.